### PR TITLE
Fix dependency chains

### DIFF
--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -189,7 +189,7 @@ function m.generate_cmake_lists(prj)
     local project_deps = ""
     
     -- include cmake dependencies
-    for _, dep in ipairs(project.getdependencies(prj, "dependOnly")) do
+    for _, dep in ipairs(project.getdependencies(prj)) do
         wks = prj.workspace
         for prj in workspace.eachproject(wks) do
             if prj.name == dep.name then

--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -197,7 +197,10 @@ function m.generate_cmake_lists(prj)
                 local f = io.open(cmakef,"r")
                 if f ~= nil then 
                     io.close(f)
+                    -- Guarantee that we aren't defining the project more than once
+                    p.x('if(NOT TARGET %s)', prj.name)
                     p.x('include(%s)', cmakef)
+                    p.x('endif()')
                     project_deps = (project_deps .. " " .. prj.name)
                 end
             end 


### PR DESCRIPTION
I have a project with two library projects and one application project. They depend on each other in a chain-like fashion: `Core (lib) -> Graphics (lib) -> Sample App` and it seems that CMake doesn't like it when you define a project more than once, so I added a guard to make sure it only does it once.

I also made it treat link-dependant projects as dependencies.