### PR TITLE
Added optional path to export APK/AAR files at the end of the build

### DIFF
--- a/android_studio/_preload.lua
+++ b/android_studio/_preload.lua
@@ -187,3 +187,17 @@ p.api.register
     scope = "project",
     kind = "list:string"
 }
+
+p.api.register
+{
+    name = "applicationoutputpath",
+    scope = "project",
+    kind = "string"
+}
+
+p.api.register
+{
+    name = "libraryoutputpath",
+    scope = "project",
+    kind = "string"
+}

--- a/android_studio/_preload.lua
+++ b/android_studio/_preload.lua
@@ -190,14 +190,14 @@ p.api.register
 
 p.api.register
 {
-    name = "applicationoutputpath",
+    name = "apkoutputpath",
     scope = "project",
     kind = "string"
 }
 
 p.api.register
 {
-    name = "libraryoutputpath",
+    name = "aaroutputpath",
     scope = "project",
     kind = "string"
 }

--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -467,19 +467,19 @@ function m.generate_project(prj)
     p.pop('}')
     
     -- applicationVariants
-    if prj.applicationoutputpath ~= nil then
+    if prj.apkoutputpath ~= nil then
         p.push('applicationVariants.all { variant ->')
         p.push('variant.outputs.all { output ->')
-        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".apk")', prj.applicationoutputpath)
+        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".apk")', prj.apkoutputpath)
         p.pop('}')
         p.pop('}')
     end
 
     -- libraryVariants
-    if prj.libraryoutputpath ~= nil then
+    if prj.aaroutputpath ~= nil then
         p.push('libraryVariants.all { variant ->')
         p.push('variant.outputs.all { output ->')
-        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".aar")', prj.libraryoutputpath)
+        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".aar")', prj.aaroutputpath)
         p.pop('}')
         p.pop('}')
     end

--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -466,6 +466,24 @@ function m.generate_project(prj)
     p.w("abortOnError = false")
     p.pop('}')
     
+    -- applicationVariants
+    if prj.applicationoutputpath ~= nil then
+        p.push('applicationVariants.all { variant ->')
+        p.push('variant.outputs.all { output ->')
+        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".apk")', prj.applicationoutputpath)
+        p.pop('}')
+        p.pop('}')
+    end
+
+    -- libraryVariants
+    if prj.libraryoutputpath ~= nil then
+        p.push('libraryVariants.all { variant ->')
+        p.push('variant.outputs.all { output ->')
+        p.x('outputFileName = new File("%s" + variant.buildType.name, project.name + ".aar")', prj.libraryoutputpath)
+        p.pop('}')
+        p.pop('}')
+    end
+
     p.pop('}') -- android
             
     -- project dependencies, java links, etc

--- a/readme.md
+++ b/readme.md
@@ -74,10 +74,10 @@ androidversioncode "1"
 androidversionname "1.0"
 
 -- Relative path to export the APK
-applicationoutputpath "./../../../../../builds"
+apkoutputpath "./../../../../../builds"
 
 -- Relative path to export the AAR
-libraryoutputpath "./../../../../libs"
+aaroutputpath "./../../../../libs"
 
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ androidkeypassword "Pr0ductK3yPa$$word"
 androidversioncode "1"
 androidversionname "1.0"
 
+-- Relative path to export the APK
+applicationoutputpath "./../../../../../builds"
+
+-- Relative path to export the AAR
+libraryoutputpath "./../../../../libs"
+
 ```
 
 *****


### PR DESCRIPTION
These changes make it possible to set a relative path to export APK or AAR files after the gradle build. My use case for this change is that I needed all builds generated from premake in the same `bin` folder separated by platform. 