### PR TITLE
Added android.ndkVersion support.

### DIFF
--- a/android_studio/_preload.lua
+++ b/android_studio/_preload.lua
@@ -241,6 +241,13 @@ p.api.register
 
 p.api.register 
 {
+    name = "androidndkversion",
+    scope = "project",
+    kind = "string"
+}
+
+p.api.register 
+{
     name = "assetpacks",
     scope = "workspace",
     kind = "key-array"

--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -492,6 +492,17 @@ function m.generate_project(prj)
     if prj.androidndkpath ~= nil then
         p.x('ndkPath \"%s\"', prj.androidndkpath)
     end
+
+    if prj.androidndkversion ~= nil then
+        p.x('ndkVersion \"%s\"', prj.androidndkversion)
+    else
+        if prj.androidndkpath ~= nil then
+            local _, _, ndk_version = string.find(prj.androidndkpath, "ndk/(.+)")
+            if ndk_version ~= nil then
+                p.x('ndkVersion \"%s\"', ndk_version)
+            end
+        end
+    end
     
     p.push('defaultConfig {')
     if prj.androidappid then


### PR DESCRIPTION
Hi, here's the output from gradle when I recently used this to build an Android release.
```
> Configure project :app
Evaluating project ':app' using build file 'app/build.gradle'.
C/C++: android.ndkVersion from module build.gradle is [not set]
C/C++: android.ndkPath from module build.gradle is /usr/local/lib/android/sdk/ndk/26r
```

Added gradle `android.ndkVersion` property support.