### PR TITLE
Fix not able to set 'androidnamespace' field in project scope

### DIFF
--- a/android_studio/_preload.lua
+++ b/android_studio/_preload.lua
@@ -155,7 +155,7 @@ p.api.register
 p.api.register 
 {
     name = "androidnamespace",
-    scope = "workspace",
+    scope = "project",
     kind = "string"
 }
 


### PR DESCRIPTION
This makes it so you can have different namespaces/bundleIDs for projects in a multi-project workspace (e.g. an app project and a library project for instance)