### PR TITLE
Updated cmake_minimum_version from 3.0 to 3.10 to work with latest NDK's

### DIFF
--- a/android_studio/android_studio.lua
+++ b/android_studio/android_studio.lua
@@ -317,7 +317,7 @@ function m.csv_string_from_table(tab)
 end
     
 function m.generate_cmake_lists(prj)
-    p.w('cmake_minimum_required (VERSION 3.0)')
+    p.w('cmake_minimum_required (VERSION 3.10)')
     
     cmake_file_exts =
     {


### PR DESCRIPTION
When used with the Android NDK version 27.0.12077973, the gradle sync fails with the following error:

```
CMake Error at D:/AndroidSDK/ndk/27.0.12077973/build/cmake/flags.cmake:46 (if):
  if given arguments:

    "hwaddress" "IN_LIST" "ANDROID_SANITIZE"
```

When `cmake_minimum_required` is changed form version `3.0` to '3.10` the above error will be fixed. 